### PR TITLE
feat: add ignoreFiles setting to exclude files based on the name

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,3 +12,4 @@ This extension has the following settings:
 
 * `magic-json.enable`: enable/disable this extension
 * `magic-json.colorSizeLimits`: display the text in the specified color if the json object size fall in the specified limits
+* `magic-json.ignoreFiles`: ignore the specified files

--- a/package.json
+++ b/package.json
@@ -9,7 +9,7 @@
 	},
 	"publisher": "Odonno",
 	"icon": "images/logo.png",
-	"version": "1.0.1",
+	"version": "1.0.2",
 	"engines": {
 		"vscode": "^1.30.0"
 	},
@@ -22,12 +22,17 @@
 	"main": "./out/extension.js",
 	"contributes": {
 		"configuration": {
-			"title": "magic-json configuration",
+			"title": "Magic JSON",
 			"properties": {
 				"magic-json.enable": {
 					"type": "boolean",
 					"default": true,
 					"description": "Enable the extension"
+				},
+				"magic-json.ignoreFiles": {
+					"type": "array",
+					"default": [],
+					"description": "Desactivate the extension for the specified files"
 				},
 				"magic-json.colorSizeLimits": {
 					"type": "array",
@@ -65,7 +70,7 @@
 		"@types/node": "^8.10.25",
 		"tslint": "^5.8.0",
 		"typescript": "^3.1.4",
-		"vscode": "^1.1.25"
+		"vscode": "^1.1.37"
 	},
 	"dependencies": {
 		"json-source-map": "^0.4.0"

--- a/package.json
+++ b/package.json
@@ -73,6 +73,7 @@
 		"vscode": "^1.1.37"
 	},
 	"dependencies": {
-		"json-source-map": "^0.4.0"
+		"json-source-map": "^0.4.0",
+		"micromatch": "^4.0.7"
 	}
 }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -1,12 +1,7 @@
 import { ExtensionContext, workspace, TextDocument, window, Range, Position, WorkspaceConfiguration } from 'vscode';
 import { convertJsonIntoObject, extractInsights, convertSizeToString, Node, convertStringToSize } from './core';
 const jsonMap = require('json-source-map');
-
-enum TypeOs {
-	WINDOWS = "win32",
-	LINUX = "linux",
-	MAC = "darwin"
-}
+const micromatch = require('micromatch');
 
 type ColorSizeLimit = {
 	from: string;
@@ -47,11 +42,9 @@ const decorationType = window.createTextEditorDecorationType({ after: { margin: 
 
 const processActiveFile = async (document: TextDocument) => {
 	const { enable, ignoreFiles } = workspace.getConfiguration('magic-json') as MagicJsonConfiguration;
-	const platform = process.platform;
-	const separator = platform === TypeOs.WINDOWS ? '\\' : '/';
-	const currentFilename = document.fileName.split(separator).slice(-1)[0];
+	const isMatch = ignoreFiles && micromatch.contains(document.fileName, ignoreFiles);
 
-	if (!enable || (ignoreFiles && ignoreFiles.includes(currentFilename))) {
+	if (!enable || isMatch) {
 		return;
 	}
 

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -2,6 +2,12 @@ import { ExtensionContext, workspace, TextDocument, window, Range, Position, Wor
 import { convertJsonIntoObject, extractInsights, convertSizeToString, Node, convertStringToSize } from './core';
 const jsonMap = require('json-source-map');
 
+enum TypeOs {
+	WINDOWS = "win32",
+	LINUX = "linux",
+	MAC = "darwin"
+}
+
 type ColorSizeLimit = {
 	from: string;
 	to: string;
@@ -15,6 +21,7 @@ type ColorMatchLimit = {
 type MagicJsonConfiguration = {
 	enable: boolean | undefined;
 	colorSizeLimits: ColorSizeLimit[] | undefined;
+	ignoreFiles: string[];
 } & WorkspaceConfiguration;
 
 /**
@@ -39,9 +46,12 @@ export const deactivate = () => { }
 const decorationType = window.createTextEditorDecorationType({ after: { margin: '0 0 0 1rem' } });
 
 const processActiveFile = async (document: TextDocument) => {
-	const { enable } = workspace.getConfiguration('magic-json') as MagicJsonConfiguration;
+	const { enable, ignoreFiles } = workspace.getConfiguration('magic-json') as MagicJsonConfiguration;
+	const platform = process.platform;
+	const separator = platform === TypeOs.WINDOWS ? '\\' : '/';
+	const currentFilename = document.fileName.split(separator).slice(-1)[0];
 
-	if (!enable) {
+	if (!enable || (ignoreFiles && ignoreFiles.includes(currentFilename))) {
 		return;
 	}
 


### PR DESCRIPTION
Very basic implementation to exclude some files.
For example, I don't need to process package.json files.
In the vs code settings, simply add:
...
"magic-json.ignoreFiles": ["package.json"],
...

To exclude package.json files.
It's a very basic implementation. A better version should managed the complete path.
For my use case, it's enough. Thank you guy for this straight forward vscode extension